### PR TITLE
Add extra proxy domain and fix hung goroutines on completion error

### DIFF
--- a/internal/handlers/completion_handler.go
+++ b/internal/handlers/completion_handler.go
@@ -112,7 +112,7 @@ func (c *CompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), time.Second*10)
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second*60)
 	r = r.WithContext(ctx)
 	defer cancel()
 	doneChan := make(chan struct{})

--- a/internal/handlers/completion_handler.go
+++ b/internal/handlers/completion_handler.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
-	"sync"
 	"text/template"
 	"time"
 
@@ -112,8 +112,10 @@ func (c *CompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second*10)
+	r = r.WithContext(ctx)
+	defer cancel()
+	doneChan := make(chan struct{})
 	err := c.api.Generate(r.Context(), &generate, func(resp api.GenerateResponse) error {
 		response := CompletionResponse{
 			Id:      uuid.New().String(),
@@ -128,22 +130,29 @@ func (c *CompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		_, err := w.Write([]byte("data: "))
 		if err != nil {
-			log.Printf("failed to write response: %s", err.Error())
+			cancel()
+			return err
 		}
 
 		err = json.NewEncoder(w).Encode(response)
 		if err != nil {
-			log.Printf("failed to write response: %s", err.Error())
-			return nil
+			cancel()
+			return err
+		}
+		if resp.Done {
+			close(doneChan)
 		}
 
-		if resp.Done {
-			wg.Done()
-		}
 		return nil
 	})
 
-	wg.Wait()
+	if err == nil {
+		select {
+		case <-r.Context().Done():
+			err = r.Context().Err()
+		case <-doneChan:
+		}
+	}
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -35,6 +35,7 @@ var hosts = []string{
 	"api.github.com",
 	"copilot-proxy.githubusercontent.com",
 	"proxy.individual.githubcopilot.com",
+	"copilot-telemetry.githubusercontent.com",
 }
 
 func handle(conn net.Conn, forward string) {

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -30,6 +30,13 @@ func Proxy(port string, forward string) {
 	}
 }
 
+var hosts = []string{
+	"api.githubcopilot.com",
+	"api.github.com",
+	"copilot-proxy.githubusercontent.com",
+	"proxy.individual.githubcopilot.com",
+}
+
 func handle(conn net.Conn, forward string) {
 	req, err := http.ReadRequest(bufio.NewReader(conn))
 	if err != nil {
@@ -40,7 +47,15 @@ func handle(conn net.Conn, forward string) {
 
 	address := "localhost" + forward
 
-	if !strings.Contains(req.URL.Hostname(), "api.githubcopilot.com") && !strings.Contains(req.URL.Hostname(), "api.github.com") && !strings.Contains(req.URL.Hostname(), "copilot-proxy.githubusercontent.com") {
+	var knownHost bool
+	for _, host := range hosts {
+		if strings.Contains(req.URL.Hostname(), host) {
+			knownHost = true
+			break
+		}
+	}
+
+	if !knownHost {
 		address = fmt.Sprintf("%s:%s", req.URL.Hostname(), req.URL.Port())
 	}
 

--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -45,18 +45,14 @@ func handle(conn net.Conn, forward string) {
 		return
 	}
 
-	address := "localhost" + forward
+	address := fmt.Sprintf("%s:%s", req.URL.Hostname(), req.URL.Port())
 
-	var knownHost bool
 	for _, host := range hosts {
 		if strings.Contains(req.URL.Hostname(), host) {
-			knownHost = true
+			// This is a host we know and want to forward back to ourselves
+			address = "localhost" + forward
 			break
 		}
-	}
-
-	if !knownHost {
-		address = fmt.Sprintf("%s:%s", req.URL.Hostname(), req.URL.Port())
 	}
 
 	if req.Method != http.MethodConnect {


### PR DESCRIPTION
This is a fantastic little tool, thanks for putting this together!

I had an issue or 2 getting it set up:
At first I found that my requests were hanging on the waitgroup when the call to the Ollama api errored, like when I did not have the correct model pulled. Added some error checking and a context timeout to fix this, and seems like the single waitgroup was easily replaceable by a simple channel to signal when the request had finished.

Second (and more importantly), my local copilot plugin (Copilot.lua for neovim) was making its requests out to `proxy.individual.githubcopilot.com`, which was not on the list of domains to forward to the Ollama server, and the completion requests would fail. Adding it there fixed my issue.

Let me know if I am doing something wrong here and I am open to other solutions, but I could not get it working without these changes.

Ethan