### PR TITLE
Add emacs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ let g:copilot_proxy_strict_ssl = v:false
 }
 ```
 
+### Emacs
+
+(experimental)
+
+1. Install [copilot-emacs](https://github.com/copilot-emacs/copilot.el)
+1. Configure the proxy
+
+```elisp
+(use-package copilot
+  :straight (:host github :repo "copilot-emacs/copilot.el" :files ("*.el"))  ;; if you don't use "straight", install otherwise
+  :ensure t
+  ;; :hook (prog-mode . copilot-mode)
+  :bind (
+         ("C-<tab>" . copilot-accept-completion)
+         )
+  :config
+  (setq copilot-network-proxy '(:host "127.0.0.1" :port 11434 :rejectUnauthorized :json-false))
+  )
+```
+
+
 ## Roadmap
 
 - [x] Enable completions APIs usage; fill in the middle.


### PR DESCRIPTION
This PR is just a weak suggestion :slightly_smiling_face: 

I have this configuration working in my emacs, but I'm not really sure why it' working.

My doubt is that I'm setting my IDE's proxy for copilot to my local ollama port (11434), which is not one of those managed by ollama-copilot (11435–11438). However, if ollama-copilot is not running, I don't get my completions.
So I think I'm missing something important on how the system works...

If you think that this snippet might help others, please pull this code, but, if you feel that this is only confusing, please feel free to drop this PR.

