### PR TITLE
Add flake.nix.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    {
+      nixosModules.default =
+        { config, lib, ... }:
+        let
+          cfg = config.ollama-copilot;
+        in
+        {
+          options = {
+            ollama-copilot.enable = lib.mkEnableOption "Enable ollama-copilot";
+            ollama-copilot.model = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              description = "The model to use (default: don't set the option, let the app choose its default)";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            systemd.services.ollama-copilot =
+              let
+                model_opt = if cfg.model != "" then " --model " + cfg.model else "";
+              in
+              {
+                description = "Ollama Copilot";
+                wantedBy = [ "multi-user.target" ];
+                serviceConfig = {
+                  Type = "simple";
+                  ExecStart = "${lib.getExe self.packages.x86_64-linux.default} ${model_opt}";
+                  Restart = "always";
+                };
+              };
+          };
+        };
+
+      packages.x86_64-linux.default =
+        let
+          pkgs = import nixpkgs { system = "x86_64-linux"; };
+        in
+        pkgs.buildGoModule rec {
+          name = "ollama-copilot";
+          src = ./.;
+          vendorHash = "sha256-g27MqS3qk67sve/jexd07zZVLR+aZOslXrXKjk9BWtk=";
+          meta.mainProgram = "ollama-copilot";
+        };
+    };
+}


### PR DESCRIPTION
NixOS is an alternative Linux distro with some significant departures from the usual ways of doing things. The steps you give in your readme to start the server won't work on NixOS. I built this script, sort of a package spec + systemd config, for NixOS users to effectively import your server. It would be most convenient for users if this could be kept in your repo. You are welcome to tag me if anyone opens an issue related to this.