### PR TITLE
Add support for proxying gpt-4o-copilot engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ let g:copilot_proxy_strict_ssl = v:false
 }
 ```
 
+### Zed
+
+1. [Open settings](https://zed.dev/docs/configuring-zed) (ctrl + ,)
+1. Set up [edit completion proxying](https://github.com/zed-industries/zed/pull/24364):
+
+```json
+{
+    "features": {
+        "edit_prediction_provider": "copilot"
+    },
+    "show_completions_on_input": true,
+    "edit_predictions": {
+        "copilot": {
+            "proxy": "http://localhost:11435",
+            "proxy_no_verify": true
+        }
+    }
+}
+```
+
 ### Emacs
 
 (experimental)

--- a/internal/server.go
+++ b/internal/server.go
@@ -109,6 +109,7 @@ func (s *Server) mux() http.Handler {
 	mux.Handle("/copilot_internal/v2/token", handlers.NewTokenHandler())
 	mux.Handle("/v1/engines/copilot-codex/completions", handlers.NewCompletionHandler(api, s.Model, templ, s.NumPredict))
 	mux.Handle("/v1/engines/chat-control/completions", handlers.NewCompletionHandler(api, s.Model, templ, s.NumPredict))
+  mux.Handle("/v1/engines/gpt-4o-copilot/completions", handlers.NewCompletionHandler(api, s.Model, templ, s.NumPredict))
 
 	return middleware.LogMiddleware(mux)
 }


### PR DESCRIPTION
I have recently switched to [Zed](https://zed.dev) code editor, which I had come to be very fond of. Soon I noticed that they offer code predictions, but [no option for local models](https://github.com/zed-industries/zed/issues/15968). I went looking for solutions. It appears that they [had recently added prediction model proxying](https://github.com/zed-industries/zed/pull/24364), which allowed the use of this CLI.

However, after trying it out, I noticed that proxying wouldn't work, because Zed would make requests to `/v1/engines/gpt-4o-copilot/completions`, which wasn't being proxied through this CLI.

Therefore, I decided to proxy `/v1/engines/gpt-4o-copilot/completions` through this CLI and it seemed to have worked out.

I must note, that I had tested this PR only with `qwen2.5-coder` model, not `codellama` (not enough GPU VRAM), therefore I cannot vouch for proper functionality with `codellama`, although I have no reason to believe anything would break.