### PR TITLE
Set X-Github-Request-Id for copilot-language-server

### DIFF
--- a/internal/middleware/github_headers.go
+++ b/internal/middleware/github_headers.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+func GithubHeaderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The copilot-language-server npm module uses this
+		// header to check if the connection to GitHub is working,
+		// and otherwise errors out.
+		w.Header().Set("x-github-request-id", "foobar")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -111,5 +111,5 @@ func (s *Server) mux() http.Handler {
 	mux.Handle("/v1/engines/chat-control/completions", handlers.NewCompletionHandler(api, s.Model, templ, s.NumPredict))
   mux.Handle("/v1/engines/gpt-4o-copilot/completions", handlers.NewCompletionHandler(api, s.Model, templ, s.NumPredict))
 
-	return middleware.LogMiddleware(mux)
+	return middleware.LogMiddleware(middleware.GithubHeaderMiddleware(mux))
 }


### PR DESCRIPTION
This language server implementation seems to be used by Zed. With this change the integration with Zed through the proxy override works as intended