### PR TITLE
Add debug logging for proxy connections

### DIFF
--- a/internal/proxy.go
+++ b/internal/proxy.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func Proxy(port string, forward string) {
+func Proxy(port string, forward string, debug bool) {
 	listener, err := net.Listen("tcp", port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
@@ -21,10 +21,13 @@ func Proxy(port string, forward string) {
 	defer listener.Close()
 
 	for {
-		//TODO #33:30min We need introduce logs here to discovery the local address and remote address and control logs using debugging flags
 		conn, err := listener.Accept()
 		if err != nil {
 			log.Fatalf("failed to accept: %v", err)
+		}
+
+		if debug {
+			log.Printf("accepted connection from %s to %s", conn.RemoteAddr(), conn.LocalAddr())
 		}
 
 		go handle(conn, forward)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	numPredict   = flag.Int("num-predict", 50, "Number of predictions to return")
 	templateStr  = flag.String("template", "<PRE> {{.Prefix}} <SUF> {{.Suffix}} <MID>", "Fill-in-middle template to apply in prompt")
 	system       = flag.String("system", "You are a helpful coding assistant. Respond with autocomplete code only, without explanations or comments.", "The system parameter is use to provide system-level instructions to guide the model's behavior throughout the conversation")
+	debug        = flag.Bool("debug", false, "Enable debug logging")
 )
 
 // main is the entrypoint for the program.
@@ -37,8 +38,8 @@ func main() {
 		System:      *system,
 	}
 
-	go internal.Proxy(*proxyPortSSL, *portSSL)
-	go internal.Proxy(*proxyPort, *port)
+	go internal.Proxy(*proxyPortSSL, *portSSL, *debug)
+	go internal.Proxy(*proxyPort, *port, *debug)
 
 	go server.Serve()
 	server.ServeTLS()


### PR DESCRIPTION
Implemented debug logging for proxy connections as requested in TODO #33.
Added a `-debug` flag to the application. When enabled, the proxy logs the remote and local addresses of accepted connections.
This helps in discovering the local and remote address for debugging purposes.

---
*PR created automatically by Jules for task [17196861443423167144](https://jules.google.com/task/17196861443423167144) started by @bernardo-bruning*