### PR TITLE
Fix issue #43: Replace log.Fatalf with log.Printf in CompletionHandler

### DIFF
--- a/internal/handlers/completion_handler.go
+++ b/internal/handlers/completion_handler.go
@@ -72,8 +72,7 @@ func (c *CompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	req := CompletionRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		// TODO #38:30min Change to log and test the issue to fix
-		log.Fatalf("error decode: %s", err.Error())
+		log.Printf("error decode: %s", err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/internal/handlers/completion_handler_test.go
+++ b/internal/handlers/completion_handler_test.go
@@ -1,0 +1,38 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bernardo-bruning/ollama-copilot/internal/handlers"
+	"github.com/bernardo-bruning/ollama-copilot/internal/ports"
+)
+
+type mockProvider struct{}
+
+func (m *mockProvider) Completion(ctx context.Context, req ports.CompletionRequest, callback func(resp ports.CompletionResponse) error) error {
+	return nil
+}
+
+func TestCompletionHandler_InvalidJSON(t *testing.T) {
+	provider := &mockProvider{}
+	h := handlers.NewCompletionHandler(provider)
+
+	// Invalid JSON body
+	reqBody := strings.NewReader(`{ "invalid": `)
+	req, err := http.NewRequest("POST", "/completion", reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}


### PR DESCRIPTION
Replaced `log.Fatalf` with `log.Printf` in `internal/handlers/completion_handler.go` to prevent the server from crashing when receiving invalid JSON. Added a regression test and removed the TODO comment.

---
*PR created automatically by Jules for task [3405723197423026794](https://jules.google.com/task/3405723197423026794) started by @bernardo-bruning*