### PR TITLE
Added num-ctx to set the ollama model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can configure the server using command-line flags:
 | `-token` | `TOKEN` | Token to pass for provider |
 | `-model` | `codellama:code` | LLM model to use |
 | `-num-predict` | `250` | Number of tokens to predict (recommended `25` for copilot) |
+| `-num-ctx` | `16384` | Context window size for model |
 | `-template` | `<PRE> {{.Prefix}} <SUF> {{.Suffix}} <MID>` | Prompt template for fill-in-middle |
 | `-system` | `You are a helpful...` | System prompt to guide the model |
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can configure the server using command-line flags:
 | `-token` | `TOKEN` | Token to pass for provider |
 | `-model` | `codellama:code` | LLM model to use |
 | `-num-predict` | `250` | Number of tokens to predict (recommended `25` for copilot) |
-| `-num-ctx` | `16384` | Context window size for model |
+| `-num-ctx` | | Context window size for model |
 | `-template` | `<PRE> {{.Prefix}} <SUF> {{.Suffix}} <MID>` | Prompt template for fill-in-middle |
 | `-system` | `You are a helpful...` | System prompt to guide the model |
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             ollama-copilot.num-ctx = lib.mkOption {
               type = lib.types.int;
               default = 0;
-              description = "Size of the context window for the model (default: 16384)";
+              description = "Size of the context window for the model";
             };
             ollama-copilot.port = lib.mkOption {
               type = lib.types.str;

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,11 @@
               default = 0;
               description = "Number of predictions to return (default: 50)";
             };
+            ollama-copilot.num-ctx = lib.mkOption {
+              type = lib.types.int;
+              default = 0;
+              description = "Size of the context window for the model (default: 16384)";
+            };
             ollama-copilot.port = lib.mkOption {
               type = lib.types.str;
               default = "";
@@ -73,6 +78,7 @@
                 key_opt = if cfg.key != "" then " -key " + cfg.key else "";
                 model_opt = if cfg.model != "" then " -model " + cfg.model else "";
                 num_predict_opt = if cfg.num-predict != 0 then " -num-predict " + toString cfg.num-predict else "";
+                num_ctx_opt = if cfg.num-ctx != 0 then " -num-predict " + toString cfg.num-ctx else "";
                 port_opt = if cfg.port != "" then " -port " + cfg.port else "";
                 port_ssl_opt = if cfg.port-ssl != "" then " -port-ssl " + cfg.port-ssl else "";
                 proxy_port_opt = if cfg.proxy-port != "" then " -proxy-port " + cfg.proxy-port else "";
@@ -85,7 +91,7 @@
                 wantedBy = [ "multi-user.target" ];
                 serviceConfig = {
                   Type = "simple";
-                  ExecStart = "${lib.getExe self.packages.x86_64-linux.default}${cert_opt}${key_opt}${model_opt}${num_predict_opt}${port_opt}${port_ssl_opt}${proxy_port_opt}${proxy_port_ssl_opt}${system_opt}${template_opt}";
+                  ExecStart = "${lib.getExe self.packages.x86_64-linux.default}${cert_opt}${key_opt}${model_opt}${num_predict_opt}${num_ctx_opt}${port_opt}${port_ssl_opt}${proxy_port_opt}${proxy_port_ssl_opt}${system_opt}${template_opt}";
                   Restart = "always";
                 };
               };

--- a/internal/adapters/factory.go
+++ b/internal/adapters/factory.go
@@ -8,10 +8,10 @@ import (
 
 var ErrUnknownProvider = errors.New("unknown provider")
 
-func NewProvider(provider string, model string, token string, numPredict int, system string, templateStr string) (ports.Provider, error) {
+func NewProvider(provider string, model string, token string, numPredict int, numCtx int, system string, templateStr string) (ports.Provider, error) {
 	switch provider {
 	case "ollama":
-		return NewOllama(model, token, numPredict, system)
+		return NewOllama(model, token, numPredict, numCtx, system)
 	case "openrouter":
 		return NewOpenRouter(token, model, system, templateStr), nil
 	case "deepseek":

--- a/internal/adapters/factory_test.go
+++ b/internal/adapters/factory_test.go
@@ -12,19 +12,20 @@ func TestFactory(t *testing.T) {
 		provider   string
 		model      string
 		numPredict int
+		numCtx     int
 		typeName   string
 		err        error
 	}{
-		{"ollama", "llama2", 128, "Ollama", nil},
-		{"openrouter", "openrouter-gpt-3.5-turbo", 256, "OpenRouter", nil},
-		{"deepseek", "deepseek-coder", 256, "DeepSeek", nil},
-		{"mistral", "mistral-tiny", 256, "Mistral", nil},
-		{"openai", "o1", 256, "OpenAI", nil},
-		{"unknown", "", 256, "", adapters.ErrUnknownProvider},
+		{"ollama", "llama2", 128, 16384, "Ollama", nil},
+		{"openrouter", "openrouter-gpt-3.5-turbo", 256, 16384, "OpenRouter", nil},
+		{"deepseek", "deepseek-coder", 256, 16384, "DeepSeek", nil},
+		{"mistral", "mistral-tiny", 256, 16384, "Mistral", nil},
+		{"openai", "o1", 256, 16384, "OpenAI", nil},
+		{"unknown", "", 256, 16384, "", adapters.ErrUnknownProvider},
 	}
 
 	for _, test := range tests {
-		provider, err := adapters.NewProvider(test.provider, test.model, "", test.numPredict, "system", "")
+		provider, err := adapters.NewProvider(test.provider, test.model, "", test.numPredict, test.numCtx, "system", "")
 		if err != test.err {
 			t.Fatalf("expected error %v, got %v", test.err, err)
 		}

--- a/internal/adapters/factory_test.go
+++ b/internal/adapters/factory_test.go
@@ -16,12 +16,12 @@ func TestFactory(t *testing.T) {
 		typeName   string
 		err        error
 	}{
-		{"ollama", "llama2", 128, 16384, "Ollama", nil},
-		{"openrouter", "openrouter-gpt-3.5-turbo", 256, 16384, "OpenRouter", nil},
-		{"deepseek", "deepseek-coder", 256, 16384, "DeepSeek", nil},
-		{"mistral", "mistral-tiny", 256, 16384, "Mistral", nil},
-		{"openai", "o1", 256, 16384, "OpenAI", nil},
-		{"unknown", "", 256, 16384, "", adapters.ErrUnknownProvider},
+		{"ollama", "llama2", 128, 0, "Ollama", nil},
+		{"openrouter", "openrouter-gpt-3.5-turbo", 256, 0, "OpenRouter", nil},
+		{"deepseek", "deepseek-coder", 256, 0, "DeepSeek", nil},
+		{"mistral", "mistral-tiny", 256, 0, "Mistral", nil},
+		{"openai", "o1", 256, 0, "OpenAI", nil},
+		{"unknown", "", 256, 0, "", adapters.ErrUnknownProvider},
 	}
 
 	for _, test := range tests {

--- a/internal/adapters/ollama.go
+++ b/internal/adapters/ollama.go
@@ -14,6 +14,7 @@ import (
 type Ollama struct {
 	model      string
 	numPredict int
+	numCtx     int
 	system     string
 	client     *api.Client
 }
@@ -31,7 +32,7 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // NewOllama creates a new Ollama adapter
-func NewOllama(model string, token string, numPredict int, system string) (ports.Provider, error) {
+func NewOllama(model string, token string, numPredict int, numCtx int, system string) (ports.Provider, error) {
 	host := os.Getenv("OLLAMA_HOST")
 	if host == "" {
 		host = "http://127.0.0.1:11434"
@@ -58,6 +59,7 @@ func NewOllama(model string, token string, numPredict int, system string) (ports
 	return &Ollama{
 		model:      model,
 		numPredict: numPredict,
+		numCtx:     numCtx,
 		client:     client,
 		system:     system,
 	}, nil
@@ -75,6 +77,7 @@ func (o *Ollama) Completion(ctx context.Context, req ports.CompletionRequest, ca
 			"top_p":       req.TopP,
 			"stop":        append(req.Stop, "<EOT>"),
 			"num_predict": o.numPredict,
+			"num_ctx":     o.numCtx,
 		},
 	}
 

--- a/internal/adapters/ollama.go
+++ b/internal/adapters/ollama.go
@@ -77,8 +77,11 @@ func (o *Ollama) Completion(ctx context.Context, req ports.CompletionRequest, ca
 			"top_p":       req.TopP,
 			"stop":        append(req.Stop, "<EOT>"),
 			"num_predict": o.numPredict,
-			"num_ctx":     o.numCtx,
 		},
+	}
+
+	if o.numCtx > 0 {
+		generate.Options["num_ctx"] = o.numCtx
 	}
 
 	return o.client.Generate(ctx, &generate, func(resp api.GenerateResponse) error {

--- a/internal/adapters/ollama_api_test.go
+++ b/internal/adapters/ollama_api_test.go
@@ -57,7 +57,7 @@ func TestOllamaCompletionAddsEOT(t *testing.T) {
 
 	// Create the Ollama adapter
 	// Note: NewOllama calls api.ClientFromEnvironment() which reads OLLAMA_HOST
-	adapter, err := NewOllama("test-model", "", 100, "test-system")
+	adapter, err := NewOllama("test-model", "", 100, 16384, "test-system")
 	if err != nil {
 		t.Fatalf("NewOllama failed: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestOllamaCompletionWithToken(t *testing.T) {
 
 	t.Setenv("OLLAMA_HOST", server.URL)
 
-	adapter, err := NewOllama("test-model", token, 100, "test-system")
+	adapter, err := NewOllama("test-model", token, 100, 16384, "test-system")
 	if err != nil {
 		t.Fatalf("NewOllama failed: %v", err)
 	}

--- a/internal/adapters/ollama_api_test.go
+++ b/internal/adapters/ollama_api_test.go
@@ -57,7 +57,7 @@ func TestOllamaCompletionAddsEOT(t *testing.T) {
 
 	// Create the Ollama adapter
 	// Note: NewOllama calls api.ClientFromEnvironment() which reads OLLAMA_HOST
-	adapter, err := NewOllama("test-model", "", 100, 16384, "test-system")
+	adapter, err := NewOllama("test-model", "", 100, 0, "test-system")
 	if err != nil {
 		t.Fatalf("NewOllama failed: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestOllamaCompletionWithToken(t *testing.T) {
 
 	t.Setenv("OLLAMA_HOST", server.URL)
 
-	adapter, err := NewOllama("test-model", token, 100, 16384, "test-system")
+	adapter, err := NewOllama("test-model", token, 100, 0, "test-system")
 	if err != nil {
 		t.Fatalf("NewOllama failed: %v", err)
 	}

--- a/internal/server.go
+++ b/internal/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	Token       string
 	Model       string
 	NumPredict  int
+	NumCtx      int
 	System      string
 }
 
@@ -96,7 +97,7 @@ func selfAssignCertificate() (tls.Certificate, error) {
 
 // mux returns the main mux for the server.
 func (s *Server) mux() http.Handler {
-	provider, err := adapters.NewProvider(s.Provider, s.Model, s.Token, s.NumPredict, s.System, s.Template)
+	provider, err := adapters.NewProvider(s.Provider, s.Model, s.Token, s.NumPredict, s.NumCtx, s.System, s.Template)
 	if err != nil {
 		log.Fatalf("error initialize api: %s", err.Error())
 		return nil

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	key          = flag.String("key", "", "Key file path *.key")
 	model        = flag.String("model", "codellama:code", "LLM model to use")
 	numPredict   = flag.Int("num-predict", 250, "Number of predictions to return")
-	numCtx       = flag.Int("num-ctx", 16384, "Context window size to use with the model")
+	numCtx       = flag.Int("num-ctx", 0, "Context window size to use with the model")
 	templateStr  = flag.String("template", "<PRE> {{.Prefix}} <SUF> {{.Suffix}} <MID>", "Fill-in-middle template to apply in prompt")
 	system       = flag.String("system", "You are a helpful coding assistant. Respond with autocomplete code only, without explanations or comments.", "The system parameter is use to provide system-level instructions to guide the model's behavior throughout the conversation")
 	debug        = flag.Bool("debug", false, "Enable debug logging")

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	key          = flag.String("key", "", "Key file path *.key")
 	model        = flag.String("model", "codellama:code", "LLM model to use")
 	numPredict   = flag.Int("num-predict", 250, "Number of predictions to return")
+	numCtx       = flag.Int("num-ctx", 16384, "Context window size to use with the model")
 	templateStr  = flag.String("template", "<PRE> {{.Prefix}} <SUF> {{.Suffix}} <MID>", "Fill-in-middle template to apply in prompt")
 	system       = flag.String("system", "You are a helpful coding assistant. Respond with autocomplete code only, without explanations or comments.", "The system parameter is use to provide system-level instructions to guide the model's behavior throughout the conversation")
 	debug        = flag.Bool("debug", false, "Enable debug logging")
@@ -35,6 +36,7 @@ func main() {
 		Token:       *token,
 		Model:       *model,
 		NumPredict:  *numPredict,
+		NumCtx:      *numCtx,
 		System:      *system,
 	}
 


### PR DESCRIPTION
Added `-num-ctx` flag to configure the ollama model's option `num_ctx` so you can customize the context window size for code vs general chat when using the same ollama server. The only alternative is to set ollama's context window size globally for all models.

This feature doesn't affect other providers since they don't support a similar option. I tried to match the same style as the `-num-predict` option as best as I could, considering that was in a similar boat with only some providers allowing that configuration option.

I set the default to 16384 since that is the max supported context window for the `codellama:code` model (Ref: [codellama](https://ollama.com/library/codellama)).

[Ollama API reference](https://docs.ollama.com/api/chat#body-options-num-ctx) for the `num_ctx` model option, and
[Ollama FAQ reference](https://docs.ollama.com/faq#how-can-i-specify-the-context-window-size) regarding the options for setting the context window size.