### PR TITLE
feat: add llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ To use the default model expected by `ollama-copilot`:
 ollama pull codellama:code
 ```
 
+### llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port `17434`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman serve
+llmman pull hf.co/unsloth/Qwen3.5-0.8B-GGUF
+ollama-copilot -provider llmman -model hf.co/unsloth/Qwen3.5-0.8B-GGUF
+```
+
+If llmman is hosted elsewhere, set `LLMMAN_HOST="http://192.168.133.7:17434"`.
+
 ### DeepSeek
 
 To use DeepSeek:
@@ -92,7 +105,7 @@ You can configure the server using command-line flags:
 | `-proxy-port-ssl` | `:11435` | HTTPS proxy port |
 | `-cert` | | Certificate file path (`*.crt`) for custom TLS |
 | `-key` | | Key file path (`*.key`) for custom TLS |
-| `-provider` | `ollama` | Provider to run LLM |
+| `-provider` | `ollama` | Provider to run LLM (`ollama`, `llmman`, `openrouter`, `deepseek`, `mistral`, `openai`) |
 | `-token` | `TOKEN` | Token to pass for provider |
 | `-model` | `codellama:code` | LLM model to use |
 | `-num-predict` | `250` | Number of tokens to predict (recommended `25` for copilot) |

--- a/internal/adapters/factory.go
+++ b/internal/adapters/factory.go
@@ -12,6 +12,8 @@ func NewProvider(provider string, model string, token string, numPredict int, nu
 	switch provider {
 	case "ollama":
 		return NewOllama(model, token, numPredict, numCtx, system)
+	case "llmman":
+		return NewLlmman(model, token, numPredict, numCtx, system)
 	case "openrouter":
 		return NewOpenRouter(token, model, system, templateStr), nil
 	case "deepseek":

--- a/internal/adapters/factory_test.go
+++ b/internal/adapters/factory_test.go
@@ -17,6 +17,7 @@ func TestFactory(t *testing.T) {
 		err        error
 	}{
 		{"ollama", "llama2", 128, 0, "Ollama", nil},
+		{"llmman", "gemma4", 128, 0, "Ollama", nil},
 		{"openrouter", "openrouter-gpt-3.5-turbo", 256, 0, "OpenRouter", nil},
 		{"deepseek", "deepseek-coder", 256, 0, "DeepSeek", nil},
 		{"mistral", "mistral-tiny", 256, 0, "Mistral", nil},

--- a/internal/adapters/ollama.go
+++ b/internal/adapters/ollama.go
@@ -33,9 +33,21 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NewOllama creates a new Ollama adapter
 func NewOllama(model string, token string, numPredict int, numCtx int, system string) (ports.Provider, error) {
-	host := os.Getenv("OLLAMA_HOST")
+	return newOllamaAPI("OLLAMA_HOST", "http://127.0.0.1:11434", model, token, numPredict, numCtx, system)
+}
+
+// NewLlmman creates an adapter for llmman (https://github.com/llmmanorg/llmman),
+// a local model runner that serves the Ollama API on port 17434.
+func NewLlmman(model string, token string, numPredict int, numCtx int, system string) (ports.Provider, error) {
+	return newOllamaAPI("LLMMAN_HOST", "http://127.0.0.1:17434", model, token, numPredict, numCtx, system)
+}
+
+// newOllamaAPI creates an adapter for any server speaking the Ollama API,
+// reading the host from hostEnv and falling back to defaultHost.
+func newOllamaAPI(hostEnv string, defaultHost string, model string, token string, numPredict int, numCtx int, system string) (ports.Provider, error) {
+	host := os.Getenv(hostEnv)
 	if host == "" {
-		host = "http://127.0.0.1:11434"
+		host = defaultHost
 	}
 
 	if !strings.Contains(host, "://") {

--- a/internal/adapters/ollama_api_test.go
+++ b/internal/adapters/ollama_api_test.go
@@ -113,3 +113,38 @@ func TestOllamaCompletionWithToken(t *testing.T) {
 		t.Fatalf("Completion failed: %v", err)
 	}
 }
+
+func TestLlmmanUsesLlmmanHost(t *testing.T) {
+	// Start a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			t.Errorf("Expected path /api/generate, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"response": "ok", "done": true}`))
+	}))
+	defer server.Close()
+
+	// llmman must honour LLMMAN_HOST and ignore OLLAMA_HOST
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+	t.Setenv("LLMMAN_HOST", server.URL)
+
+	adapter, err := NewLlmman("test-model", "", 100, 0, "test-system")
+	if err != nil {
+		t.Fatalf("NewLlmman failed: %v", err)
+	}
+
+	req := ports.CompletionRequest{
+		Prompt: "test prompt",
+	}
+
+	err = adapter.Completion(context.Background(), req, func(resp ports.CompletionResponse) error {
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Completion failed: %v", err)
+	}
+}


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `internal/adapters/ollama.go`: host lookup moved from `NewOllama` into a shared `newOllamaAPI` helper; `NewOllama` behaviour is unchanged. New `NewLlmman` reuses the same adapter with `LLMMAN_HOST` / `127.0.0.1:17434`, so no new adapter type is needed.
- `internal/adapters/factory.go`: registers `-provider llmman`.
- Tests: `TestFactory` gains a `llmman` row; `TestLlmmanUsesLlmmanHost` checks `/api/generate` is hit on `LLMMAN_HOST`, ignoring `OLLAMA_HOST`.
- `README.md`: llmman section next to the other providers; `-provider` flag row lists the accepted values.

**Testing:** `go build ./...`, `go vet ./internal/adapters/` and `go test ./...` pass; `gofmt -l` clean on touched files. Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
